### PR TITLE
Add .editorconfig for tab alignment on 4 spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*]
+indent_size = 4
+indent_style = tab
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
This PR just adds an .editorconfig to align tabs on 4 spaces in Github.
It sets indent style to tabs.

Some files (like Introduction) have a mix of spaces and tabs, and by default Github aligns them to 8 spaces.

## Before

<img width="444" alt="Screenshot 2019-09-02 at 11 26 06" src="https://user-images.githubusercontent.com/2991143/64104497-9e76d880-cd74-11e9-8983-7d71ea511c3a.png">

## After

<img width="447" alt="Screenshot 2019-09-02 at 11 25 31" src="https://user-images.githubusercontent.com/2991143/64104508-a33b8c80-cd74-11e9-9fe0-e9add3934c31.png">
